### PR TITLE
Changed line 43 in gemfile to include github strategy gem per the recommended protocol on the github strategy repo's README.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'omniauth'
-  gem 'omniauth-github'
+  gem 'omniauth-github', github: 'omniauth/omniauth-github', branch: 'master'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/omniauth/omniauth-github.git
+  revision: 5afe8aee3baccd84ce6f265a3e62efbb55ac14b9
+  branch: master
+  specs:
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -80,8 +89,9 @@ GEM
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
-    faraday (0.17.0)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -91,7 +101,7 @@ GEM
     io-like (0.3.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
-    jwt (2.2.1)
+    jwt (2.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -109,13 +119,13 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.13.0)
     msgpack (1.3.1)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
-    oauth2 (1.4.2)
+    oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
@@ -124,11 +134,8 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    omniauth-github (1.3.0)
-      omniauth (~> 1.5)
-      omniauth-oauth2 (>= 1.4.0, < 2.0)
-    omniauth-oauth2 (1.6.0)
-      oauth2 (~> 1.1)
+    omniauth-oauth2 (1.7.0)
+      oauth2 (~> 1.4)
       omniauth (~> 1.9)
     public_suffix (4.0.1)
     puma (3.12.6)
@@ -181,6 +188,7 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     rubyzip (2.0.0)
     sass (3.7.4)
@@ -243,7 +251,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   omniauth
-  omniauth-github
+  omniauth-github!
   puma (~> 3.12)
   rails (~> 5.2.3)
   rspec-rails


### PR DESCRIPTION
We have had several students reach out to AAQ regarding a specific error while working through this lab. The error message is as follows:

```
{"message":"Must specify access token via Authorization header","documentation_url":"https://docs.github.com/v3/#oauth2-token-sent-in-a-header"}
```

I cloned a fresh version of this lab and was able to reproduce the issue.

By removing line 43:

`gem omniauth-github`

in the gemfile, and replacing it with what the strategy's developer has as the recommended way to include this gem:

`gem 'omniauth-github', github: 'omniauth/omniauth-github', branch: 'master'`

the error cleared and I was able to successfully authorize. Changing this line and rebundling the gemfile updates both the `oauth2` and `omniauth-oauth2` to versions 1.4.4 and 1.70, respectively. This change also updates the omniauth-github gem itself, from 1.3.0 to 1.4.0. I believe that including the gem with no specifiers, i.e. `gem omniauth-github`, causes a dependency conflict with `omniauth` regarding its requirement for an access token in the HTTP request header. Updating `omniauth-github` seems to resolve this dependency issue.